### PR TITLE
[style] TabMenu 컴포넌트 생성

### DIFF
--- a/components/tabMenu/TabMenu.module.scss
+++ b/components/tabMenu/TabMenu.module.scss
@@ -1,0 +1,41 @@
+.container {
+  display: flex;
+  width: 100%;
+  height: 65px;
+  background-color: var(--background-color);
+  justify-content: space-between;
+
+  button {
+    flex: 1;
+    height: 100%;
+    border: none;
+    background-color: transparent;
+    font-size: 20px;
+    font-weight: bold;
+    color: var(--grey-4-color);
+    text-align: center;
+    position: relative;
+    transition: color 0.3s, border-bottom 0.5s;
+  }
+  
+  button:hover {
+    color: var(--primary-color);
+    cursor: pointer;
+  }
+  
+  button.active {
+    color: var(--primary-color);
+  }
+  
+  button.active::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: var(--primary-color);
+  }
+}
+
+

--- a/components/tabMenu/TabMenu.tsx
+++ b/components/tabMenu/TabMenu.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import React, { useState } from "react";
+import styles from "./TabMenu.module.scss";
+
+interface TabMenuProps {
+  tabs: string[];
+  onTabChange: (index: number) => void;
+}
+
+const TabMenu: React.FC<TabMenuProps> = ({ tabs, onTabChange }) => {
+  const [activeTab, setActiveTab] = useState<number>(0);
+
+  const handleTabClick = (index: number) => {
+    setActiveTab(index);
+    onTabChange(index);
+  };
+
+  return (
+    <div className={styles.container}>
+      {tabs.map((tab, index) => (
+        <button
+          key={index}
+          className={activeTab === index ? styles.active : ""}
+          onClick={() => handleTabClick(index)}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default TabMenu;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능추가
- [x] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- TabMenu 컴포넌트 추가했습니다
<br />
- 사용 방법 : 메뉴 리스트와 이벤트 함수를 props로 넣어서 사용하시면 됩니다

```js
"use client"

import React, { useState } from "react";
import TabMenu from "../../../components/tabMenu/TabMenu";

const MainComponent: React.FC = () => {
  const tabs = ["약속 정보", "정산 하기", "추억 공간"];
  const [currentTab, setCurrentTab] = useState<number>(0);

  const handleTabChange = (index: number) => {
    setCurrentTab(index);
  };

  return (
    <div>
      <TabMenu tabs={tabs} onTabChange={handleTabChange} />
      <div>
        {currentTab === 0 && <p>현재 선택된 탭: 약속 정보</p>}
        {currentTab === 1 && <p>현재 선택된 탭: 정산 하기</p>}
        {currentTab === 2 && <p>현재 선택된 탭: 추억 공간</p>}
      </div>
    </div>
  );
};

export default MainComponent;

```

<br />

## :: 기타 질문 및 특이 사항

-
-
