### PR TITLE
[refactor] 컴포넌트 로직 분리 및 스타일 변경

### DIFF
--- a/app/(anon)/signup/components/AuthForm.module.scss
+++ b/app/(anon)/signup/components/AuthForm.module.scss
@@ -8,7 +8,7 @@
     .duplicateTest {
       display: grid;
       grid-template-columns: 1fr auto;
-      gap: 10px;
+      gap: 15px;
       align-items: center;
 
       button:nth-child(1) {

--- a/app/(anon)/signup/components/AuthForm.tsx
+++ b/app/(anon)/signup/components/AuthForm.tsx
@@ -2,76 +2,38 @@
 import Button from "@/components/button/Button";
 import InputField from "@/components/input-filed/InputFiled";
 import styles from "./AuthForm.module.scss";
-import { useState } from "react";
-import useInput from "../hooks/useInput";
-import {
-  validateEmail,
-  validateNickname,
-  validatePassword,
-  validatePasswordCheck,
-} from "../hooks/useValidate";
+
+import EmailInputField from "./EmailInputField";
+import useForm from "../hooks/useForm";
 
 const AuthForm = () => {
   const {
-    value: email,
-    onChange: habdleChangeEmail,
-    error: emailError,
-  } = useInput("", validateEmail);
-  const {
-    value: nickname,
-    onChange: habdleChangeNickname,
-    error: nicknameError,
-  } = useInput("", validateNickname);
-  const {
-    value: password,
-    onChange: habdleChangePassword,
-    error: passwordError,
-  } = useInput("", validatePassword);
-
-  const {
-    value: passwordCheck,
-    onChange: habdleChangePasswordCheck,
-    error: passwordCheckError,
-  } = useInput("", (value) => validatePasswordCheck(value, password));
-
-  const [submittedValues, setSubmittedValues] = useState({
-    email: "",
-    nickname: "",
-    password: "",
-    passwordCheck: "",
-  });
-
-  const isFormValid = [
-    emailError,
-    nicknameError,
-    passwordError,
-    passwordCheckError,
-    !email,
-    !nickname,
-    !password,
-    !passwordCheck,
-  ].every((error) => !error);
+    email: { email, emailError, handleChangeEmail },
+    nickname: { nickname, nicknameError, habdleChangeNickname },
+    password: { password, passwordError, habdleChangePassword },
+    passwordCheck: {
+      passwordCheck,
+      passwordCheckError,
+      habdleChangePasswordCheck,
+    },
+    isFormValid,
+  } = useForm();
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    setSubmittedValues({
-      email,
-      nickname,
-      password,
-      passwordCheck,
-    });
+    console.log(`email : ${email}
+      nickname : ${nickname}
+      password: ${password}
+      `);
   };
 
   return (
     <div className={styles.authFormContainer}>
       <form onSubmit={handleSubmit} className={styles.signupForm}>
-        <InputField
-          type="email"
+        <EmailInputField
           label="이메일"
-          value={email}
-          onChange={habdleChangeEmail}
-          placeholder="이메일을 입력해주세요"
+          onChange={handleChangeEmail}
           error={emailError}
         />
         <div className={styles.duplicateTest}>

--- a/app/(anon)/signup/components/EmailInputField.module.scss
+++ b/app/(anon)/signup/components/EmailInputField.module.scss
@@ -1,0 +1,53 @@
+.emailInputContainer {
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  .inputField {
+    flex: 3;
+  }
+
+  .atSymbol {
+    flex: 0.5;
+    text-align: center;
+    font-size: var(--font-size-md);
+    margin-top: 10px;
+  }
+
+  .domainSelect {
+    flex: 1.5;
+    padding: 8px;
+    margin-top: 10px;
+    padding: 15px;
+    width: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 10px;
+    outline: none;
+    font-size: 14px;
+
+    &::placeholder {
+      color: #898989;
+    }
+
+    &:focus {
+      border-color: #2563eb;
+    }
+  }
+
+  // .domainLabel {
+  //   display: none;
+  // }
+
+  // .domain {
+  //   padding: 15px;
+  //   margin-top: 10px;
+  //   border: 1px solid #d1d5db;
+  //   border-radius: 10px;
+  //   outline: none;
+  //   font-size: 14px;
+  //   flex: 1;
+  //   flex-grow: 1.3;
+  //   min-width: 50px;
+  //   width: auto;
+  // }
+}

--- a/app/(anon)/signup/components/EmailInputField.module.scss
+++ b/app/(anon)/signup/components/EmailInputField.module.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   .inputField {
-    flex: 3;
+    flex: 6;
   }
 
   .atSymbol {
@@ -15,8 +15,7 @@
   }
 
   .domainSelect {
-    flex: 1.5;
-    padding: 8px;
+    flex: 2.1;
     margin-top: 10px;
     padding: 15px;
     width: 100%;

--- a/app/(anon)/signup/components/EmailInputField.tsx
+++ b/app/(anon)/signup/components/EmailInputField.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import styles from "./EmailInputField.module.scss";
+import InputField from "@/components/input-filed/InputFiled";
+import useInput from "../hooks/useInput";
+import { EMAIL_DOMAINS } from "../constants/emailDomains";
+
+interface EmailInputFieldProps {
+  label: string;
+  onChange: (email: string) => void;
+  error?: string | null;
+}
+
+const EmailInputField = ({ label, onChange, error }: EmailInputFieldProps) => {
+  const { value: localEmail, setValue: setLocalEmail } = useInput("");
+  const [domain, setDomain] = useState("google.com");
+  // const domain = "moongchi.com";
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalEmail(e.target.value);
+    onChange(`${e.target.value}@${domain}`);
+  };
+
+  const handleDomainChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedDomain = e.target.value;
+    setDomain(selectedDomain);
+    onChange(`${localEmail}@${selectedDomain}`);
+  };
+
+  return (
+    <div className={styles.emailInputContainer}>
+      <div className={styles.inputField}>
+        <InputField
+          label={label}
+          type="text"
+          value={localEmail}
+          onChange={handleEmailChange}
+          placeholder="이메일 아이디"
+          error={error}
+        />
+      </div>
+      <span className={styles.atSymbol}>@</span>
+      <select
+        value={domain}
+        onChange={handleDomainChange}
+        className={styles.domainSelect}
+      >
+        {EMAIL_DOMAINS.map((dom) => (
+          <option key={dom} value={dom}>
+            {dom}
+          </option>
+        ))}
+      </select>
+
+      {/* <label className={styles.domainLabel}>도메인</label>
+      <input type="text" value={domain} disabled className={styles.domain} /> */}
+    </div>
+  );
+};
+
+export default EmailInputField;

--- a/app/(anon)/signup/constants/emailDomains.ts
+++ b/app/(anon)/signup/constants/emailDomains.ts
@@ -1,0 +1,6 @@
+export const EMAIL_DOMAINS = [
+  "gmail.com",
+  "naver.com",
+  "kakao.com",
+  "daum.net",
+];

--- a/app/(anon)/signup/hooks/useForm.ts
+++ b/app/(anon)/signup/hooks/useForm.ts
@@ -1,0 +1,64 @@
+import useInput from "./useInput";
+import {
+  validateEmail,
+  validateNickname,
+  validatePassword,
+  validatePasswordCheck,
+} from "./useValidate";
+
+const useForm = () => {
+  const {
+    value: email,
+    error: emailError,
+    onChange: handleChangeEmail,
+  } = useInput("", validateEmail);
+  const {
+    value: nickname,
+    error: nicknameError,
+    onChange: habdleChangeNickname,
+  } = useInput("", validateNickname);
+  const {
+    value: password,
+    error: passwordError,
+    onChange: habdleChangePassword,
+  } = useInput("", validatePassword);
+
+  const {
+    value: passwordCheck,
+    error: passwordCheckError,
+    onChange: habdleChangePasswordCheck,
+  } = useInput("", (value) => validatePasswordCheck(value, password));
+
+  const isFormValid = [
+    emailError,
+    nicknameError,
+    passwordError,
+    passwordCheckError,
+    !email,
+    !nickname,
+    !password,
+    !passwordCheck,
+  ].every((error) => !error);
+
+  return {
+    email: { email, emailError, handleChangeEmail },
+    nickname: {
+      nickname,
+      nicknameError,
+      habdleChangeNickname,
+    },
+    password: {
+      password,
+      passwordError,
+      habdleChangePassword,
+    },
+    passwordCheck: {
+      passwordCheck,
+      passwordCheckError,
+      habdleChangePasswordCheck,
+    },
+    isFormValid,
+  };
+};
+
+export default useForm;

--- a/app/(anon)/signup/hooks/useInput.ts
+++ b/app/(anon)/signup/hooks/useInput.ts
@@ -10,10 +10,14 @@ const useInput = (
   const [error, setError] = useState<string | null>(null);
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
+    emailOrEvent: string | React.ChangeEvent<HTMLInputElement>,
     additionalValue?: string
   ) => {
-    const newValue = e.target.value;
+    const newValue =
+      typeof emailOrEvent === "string"
+        ? emailOrEvent
+        : emailOrEvent.target.value;
+
     setValue(newValue);
 
     if (validate) {
@@ -22,7 +26,7 @@ const useInput = (
     }
   };
 
-  return { value, error, onChange: handleChange };
+  return { value, error, onChange: handleChange, setValue };
 };
 
 export default useInput;

--- a/app/(anon)/signup/hooks/useValidate.ts
+++ b/app/(anon)/signup/hooks/useValidate.ts
@@ -1,7 +1,7 @@
 export const validateEmail = (value: string) => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const emailRegex = /^[a-z0-9]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(value)) {
-    return "유효하지 않은 이메일 형식입니다.";
+    return "이메일 아이디는 소문자와 숫자만 포함할 수 있습니다.";
   }
   return null;
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능추가
- [x] 디자인 작업
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 기존 이메일 입력 필드 -> 이메일 컴포넌트를 분리하여 이메일 아이디 입력과 도메인 선택 기능 추가
- 유효성 검사 및 상태 관리 로직을 useForm 훅으로 분리

<br />

## :: 기타 질문 및 특이 사항

- 이메일 방식을 google, kakao, naver, daum으로 갈건지,,,,아니면 moong.com으로 확정적으로 쓸건지 
- 저희 맘대로 moong.com이란걸 써도 되는지랑 google, kakao, naver를 써도 되는지 둘다 연동 그런건 없고 그냥 이름만 쓰는 느낌입니다.
- moong.com 을 쓴다면 select -> input으로 변경 후 disabled 할 예정
