### PR TITLE
[fix] 비밀번호 유효성 검사 순서

### DIFF
--- a/app/(anon)/signup/hooks/useForm.ts
+++ b/app/(anon)/signup/hooks/useForm.ts
@@ -27,7 +27,11 @@ const useForm = () => {
     value: passwordCheck,
     error: passwordCheckError,
     onChange: habdleChangePasswordCheck,
-  } = useInput("", (value) => validatePasswordCheck(value, password));
+  } = useInput(
+    "",
+    (passwordCheck) => validatePasswordCheck(passwordCheck, password),
+    password
+  );
 
   const isFormValid = [
     emailError,

--- a/app/(anon)/signup/hooks/useInput.ts
+++ b/app/(anon)/signup/hooks/useInput.ts
@@ -1,17 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const useInput = (
   initialValue: string,
-  validate?: (value: string, additionalValue?: string) => string | null
+  validate?: (passwordCheck: string, password?: string) => string | null,
+  comparisonValue?: string
 ) => {
   const [value, setValue] = useState(initialValue);
   const [error, setError] = useState<string | null>(null);
+  const [isTouched, setIsTouched] = useState<boolean>(false);
 
   const handleChange = (
-    emailOrEvent: string | React.ChangeEvent<HTMLInputElement>,
-    additionalValue?: string
+    emailOrEvent: string | React.ChangeEvent<HTMLInputElement>
   ) => {
     const newValue =
       typeof emailOrEvent === "string"
@@ -20,13 +21,23 @@ const useInput = (
 
     setValue(newValue);
 
-    if (validate) {
-      const validationError = validate(newValue, additionalValue);
-      setError(validationError);
+    if (!isTouched) {
+      setIsTouched(true);
     }
   };
 
-  return { value, error, onChange: handleChange, setValue };
+  useEffect(() => {
+    if (isTouched && validate) {
+      const validationError = validate(value, comparisonValue);
+      setError(validationError);
+    }
+  }, [value, comparisonValue, validate, isTouched]);
+  return {
+    value,
+    error: isTouched ? error : null,
+    onChange: handleChange,
+    setValue,
+  };
 };
 
 export default useInput;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 기존 비밀번호 입력 후 비밀번호 확인 입력하면 검사가 잘 진행됩니다.
- 문제 : 비밀번호 확인 먼저 입력 후 비밀번호 입력하면 유효성 검사가 안됩니다, 비밀번호 입력 후 비밀번호 확인 입력한 다음 비밀번호를 수정해도 유효성 검사가 이루어지지 않습니다.
- useEffect를 사용하여 비밀번호 순서에 관계없이 비밀번호 일치 여부를 유효성 검사하도록 수정하였습니다.

<br />

## :: 기타 질문 및 특이 사항

-
-
