### PR TITLE
[style] 장소결과 페이지 디자인 추가 및 드롭다운 메뉴 기능 구현

### DIFF
--- a/app/user/appointments/[id]/vote-result/components/PlaceResult.module.scss
+++ b/app/user/appointments/[id]/vote-result/components/PlaceResult.module.scss
@@ -1,0 +1,145 @@
+.placeResultContainer {
+  height: 55vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+  position: relative;
+
+  .header {
+    position: sticky;
+    top: 0;
+    background: white;
+    z-index: 20;
+    padding-bottom: 5px;
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    font-size: var(--font-size-sm);
+
+    .dropdown {
+      background: var(--grey-2-color);
+      padding: 10px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 150px;
+      position: relative;
+      z-index: 30;
+
+      .arrow {
+        margin-left: 5px;
+        font-size: var(--font-size-xs);
+      }
+    }
+
+    .dropdownMenu {
+      position: absolute; // ✅ 드롭다운을 버튼 기준으로 정렬
+      top: 100%; // ✅ 버튼 바로 아래 배치
+      left: 0;
+      width: 100%;
+      background: #fff;
+      border: 1px solid var(--grey-4-color);
+      border-radius: 8px;
+      box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+      list-style: none;
+      padding: 5px 0;
+      z-index: 1000;
+      opacity: 0;
+      transform: translateY(-10px);
+      transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+      pointer-events: none;
+
+      &.open {
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+      }
+
+      li {
+        padding: 10px 12px;
+        cursor: pointer;
+        text-align: center;
+
+        &:hover {
+          background: var(--grey-6-color);
+        }
+      }
+    }
+  }
+
+  .placeList {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    .placeItem {
+      background: var(--grey-2-color);
+      border-radius: 10px;
+      padding: 15px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      transition: all 0.3s ease;
+
+      &.disabled {
+        opacity: 0.3;
+        pointer-events: none;
+      }
+
+      .placeHeader {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        .placeName {
+          font-size: var(--font-size-md);
+          font-weight: bold;
+        }
+
+        .placeDetail {
+          font-size: var(--font-size-sm);
+          color: #007aff;
+          text-decoration: none;
+        }
+      }
+
+      .voterList {
+        display: flex;
+        flex-direction: column;
+        align-items: start;
+        font-size: var(--font-size-xs);
+
+        .voterTitle {
+          margin: 10px 0;
+        }
+
+        .userList {
+          display: flex;
+          flex-wrap: wrap;
+
+          span {
+            color: #333;
+            background: var(--grey-6-color);
+            margin-top: 5px;
+            margin-right: 5px;
+            padding: 5px 10px;
+            border-radius: 20px;
+            font-size: var(--font-size-xs);
+          }
+        }
+
+        .noVote {
+          color: var(--grey-5-color);
+        }
+      }
+    }
+  }
+}

--- a/app/user/appointments/[id]/vote-result/components/PlaceResult.tsx
+++ b/app/user/appointments/[id]/vote-result/components/PlaceResult.tsx
@@ -1,5 +1,116 @@
-const PlaceResult = () => {
-  return <div>PlaceResult</div>;
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import styles from "./PlaceResult.module.scss";
+
+interface PlaceResult {
+  member: string[];
+  result: {
+    place: string;
+    place_url: string;
+    user: string[];
+  }[];
+}
+
+const PlaceResult = ({ placeProps }: { placeProps: PlaceResult }) => {
+  const placeResult: PlaceResult = placeProps;
+
+  const [selectedMember, setSelectedMember] = useState<string>("전체 참여자");
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  // 바깥쪽 클릭 감지
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setDropdownOpen(false); // 드롭다운 닫기
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+    };
+  }, []);
+
+  const handleSelectMember = (member: string) => {
+    setSelectedMember(member);
+    setDropdownOpen(false);
+  };
+
+  return (
+    <div className={styles.placeResultContainer}>
+      {/* 상단 전체 참여자 드롭다운 */}
+      <div className={styles.header} ref={dropdownRef}>
+        <div
+          className={styles.dropdown}
+          onClick={() => setDropdownOpen(!isDropdownOpen)}
+        >
+          {selectedMember} <span className={styles.arrow}>▼</span>
+        </div>
+        <ul
+          className={`${styles.dropdownMenu} ${
+            isDropdownOpen ? styles.open : ""
+          }`}
+        >
+          <li onClick={() => handleSelectMember("전체 참여자")}>전체 참여자</li>
+          {placeResult.member.map((member) => (
+            <li key={member} onClick={() => handleSelectMember(member)}>
+              {member}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* 장소 리스트 */}
+      <div className={styles.placeList}>
+        {placeResult.result.map((place, index) => {
+          const isSelectedUser =
+            selectedMember === "전체 참여자" ||
+            place.user.includes(selectedMember);
+
+          return (
+            <div
+              key={index}
+              className={`${styles.placeItem} ${
+                isSelectedUser ? "" : styles.disabled
+              }`}
+            >
+              <div className={styles.placeHeader}>
+                <span className={styles.placeName}>{place.place}</span>
+                {place.place_url && (
+                  <a
+                    href={place.place_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.placeDetail}
+                  >
+                    상세보기
+                  </a>
+                )}
+              </div>
+              <div className={styles.voterList}>
+                <span className={styles.voterTitle}>투표한 사람</span>
+                <div className={styles.userList}>
+                  {place.user.length > 0 ? (
+                    place.user.map((user, idx) => <span key={idx}>{user}</span>)
+                  ) : (
+                    <span className={styles.noVote}>
+                      아직 투표한 사람이 없습니다.
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 };
 
 export default PlaceResult;

--- a/app/user/appointments/[id]/vote-result/components/TimeResult.tsx
+++ b/app/user/appointments/[id]/vote-result/components/TimeResult.tsx
@@ -2,42 +2,18 @@
 import { useState } from "react";
 import styles from "./TimeResult.module.scss";
 
-interface Result {
+interface TimeResult {
   start_time: string;
   end_time: string;
   member: string[];
   result: {
     date: string;
-    count: number;
     user: string[];
   }[];
 }
 
-const TimeResult = () => {
-  const timeResult: Result = {
-    start_time: "2025-01-01 12:00:00",
-    end_time: "2025-01-07 22:00:00",
-    member: ["고뭉치", "김뭉치", "심뭉치", "이뭉치", "황뭉치", "빈뭉치"],
-    result: [
-      { date: "2025-01-01 12:00:00", count: 0, user: [] },
-      { date: "2025-01-01 13:00:00", count: 1, user: ["고뭉치"] },
-      {
-        date: "2025-01-01 14:00:00",
-        count: 2,
-        user: ["고뭉치", "심뭉치"],
-      },
-      {
-        date: "2025-01-01 15:00:00",
-        count: 3,
-        user: ["고뭉치", "김뭉치", "심뭉치"],
-      },
-      {
-        date: "2025-01-01 16:00:00",
-        count: 4,
-        user: ["고뭉치", "김뭉치", "심뭉치", "이뭉치"],
-      },
-    ],
-  };
+const TimeResult = ({ timeProps }: { timeProps: TimeResult }) => {
+  const timeResult: TimeResult = timeProps;
 
   const getDateList = (start: Date, end: Date) => {
     const dates = [];
@@ -85,11 +61,11 @@ const TimeResult = () => {
     const fullDate = `${date} ${String(hour).padStart(2, "0")}:00:00`;
     const result = timeResult.result.find((item) => item.date === fullDate);
 
-    if (!result || result.count === 0) {
+    if (!result || result.user.length === 0) {
       return styles.noVote; // 투표가 없는 경우
     }
 
-    const percentage = result.count / timeResult.member.length;
+    const percentage = result.user.length / timeResult.member.length;
     if (percentage > 0.66) return styles.highVote; // 진한 파란색
     if (percentage > 0.33) return styles.mediumVote; // 중간 파란색
     return styles.lowVote; // 연한 파란색

--- a/app/user/appointments/[id]/vote-result/page.tsx
+++ b/app/user/appointments/[id]/vote-result/page.tsx
@@ -5,12 +5,94 @@ import TimeResult from "./components/TimeResult";
 import PlaceResult from "./components/PlaceResult";
 import { useState } from "react";
 
+interface Place {
+  member: string[];
+  result: {
+    place: string;
+    place_url: string;
+    user: string[];
+  }[];
+}
+interface Time {
+  start_time: string;
+  end_time: string;
+  member: string[];
+  result: {
+    date: string;
+    user: string[];
+  }[];
+}
+
 const VoteResultPage = () => {
   const [page, setPage] = useState(1);
+
+  const [resultData, setResultData] = useState({
+    time: {
+      start_time: "2025-01-01 12:00:00",
+      end_time: "2025-01-07 22:00:00",
+      member: ["고뭉치", "김뭉치", "심뭉치", "이뭉치", "황뭉치", "빈뭉치"],
+      result: [
+        { date: "2025-01-01 12:00:00", user: [] },
+        { date: "2025-01-01 13:00:00", user: ["고뭉치"] },
+        { date: "2025-01-01 14:00:00", user: ["고뭉치", "심뭉치"] },
+        { date: "2025-01-01 15:00:00", user: ["고뭉치", "김뭉치", "심뭉치"] },
+        {
+          date: "2025-01-01 16:00:00",
+          user: ["고뭉치", "김뭉치", "심뭉치", "이뭉치"],
+        },
+      ],
+    },
+    place: {
+      member: [
+        "고뭉치",
+        "김뭉치",
+        "심뭉치",
+        "이뭉치",
+        "황뭉치",
+        "빈뭉치",
+        "가뭉치",
+        "나뭉치",
+      ],
+      result: [
+        {
+          place: "동대문역사문화공원역",
+          place_url: "https://naver.me/xEABuNEP",
+          user: ["고뭉치", "김뭉치", "심뭉치"],
+        },
+        {
+          place: "홍대입구",
+          place_url: "https://naver.me/xEABuNEP",
+          user: ["김뭉치", "심뭉치"],
+        },
+        {
+          place: "서울역",
+          place_url: "https://naver.me/xEABuNEP",
+          user: ["심뭉치"],
+        },
+        { place: "우리집", place_url: "https://naver.me/xEABuNEP", user: [] },
+        {
+          place: "롯데월드",
+          place_url: "https://naver.me/xEABuNEP",
+          user: [
+            "고뭉치",
+            "김뭉치",
+            "심뭉치",
+            "이뭉치",
+            "황뭉치",
+            "빈뭉치",
+            "가뭉치",
+            "나뭉치",
+          ],
+        },
+      ],
+    },
+  });
   return (
     <div className={styles.voteResultContainer}>
       <p className={styles.subtitle}>
-        현재까지 <span style={{ color: "red" }}>n</span> 명의 시간 조율 결과예요
+        현재까지{" "}
+        <span style={{ color: "red" }}>{resultData.time.member.length}</span>{" "}
+        명의 {page === 1 ? "시간" : "장소"} 조율 결과예요
       </p>
       <div className={styles.wrapTapButton}>
         <div className={styles.tapButton}>
@@ -32,7 +114,11 @@ const VoteResultPage = () => {
           </button>
         </div>
       </div>
-      {page === 1 ? <TimeResult /> : <PlaceResult />}
+      {page === 1 ? (
+        <TimeResult timeProps={resultData.time} />
+      ) : (
+        <PlaceResult placeProps={resultData.place} />
+      )}
       <div className={styles.wrapButton}>
         <Button text="약속 확정하러 가기" size="lg" />
       </div>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [x] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 참가자 필터링 드롭다운
* 클릭하면 참가자 목록을 드롭다운으로 표시.
* 특정 참가자를 선택하면 해당 참가자가 투표한 장소만 표시.
* `selectedMember` 상태를 변경하여 필터링 적용.
* `useRef`와 `useEffect`를 사용:
`useRef`로 드롭다운 DOM 요소(dropdownRef)를 추적.
`useEffect`로 `mousedown` 이벤트를 감지하여, 드롭다운 박스 바깥쪽 클릭 시 닫히도록 처리.
`handleOutsideClick` 함수:
`dropdownRef.current`가 클릭된 대상(event.target)을 포함하지 않으면 드롭다운을 닫음.

2. 장소 리스트
* placeResult.result 배열을 순회하며 장소를 출력.
* 장소 클릭 시 네이버 지도 링크(place_url)로 이동.
* 장소마다 투표한 사람을 user 리스트에서 표시.
* 투표한 사람이 없으면 아직 투표한 사람이 없습니다. 메시지 표시.

3. 선택한 참가자에 따른 필터링
* selectedMember가 "전체 참여자"일 경우 모든 장소 표시.
* 특정 참가자 선택 시, 해당 참가자가 투표한 장소만 표시.
* 필터링된 장소가 회색(opacity 적용)으로 비활성화됨.

4, vote-result 페이지에서 데이터를 한번에 받은 후 시간투표결과컴포넌트, 장소결과 컴포넌트로 props를 통해 데이터 전달
<br />

## :: 기타 질문 및 특이 사항

-
-
