### PR TITLE
[fix] 닉네임 변경 시 중복검사 상태 초기화 및 버튼 활성화 로직 수정

### DIFF
--- a/app/(anon)/signup/components/AuthForm.tsx
+++ b/app/(anon)/signup/components/AuthForm.tsx
@@ -127,10 +127,9 @@ const AuthForm = () => {
   ) => {
     handleChangeNickname(e);
 
-    if (!e.target.value) {
-      setNicknameCheckError(null);
-      setNicknameCheckSuccess(null);
-    }
+    setNicknameCheckError(null);
+    setNicknameCheckSuccess(null);
+    setIsNicknameAvailable(false);
   };
 
   return (


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 모든 필드 유효성 검사를 통과해야 회원가입 버튼이 활성화됩니다.
- ex) 뭉치 -> 현재 sup abasesupabase table에 있는 애칭입니다닉네임입니다.
- 만약 뭉치라는 애칭을닉네임을 중복검사 했을 때 이미 존재하는 유저이니까 모든 필드를 채워도 회원가입 버튼이 비활성화됩니다.
- 하지만 뭉치라는 애칭을닉네임을 지우고 다시 뭉치라고 입력하고 중복검사 버튼을 누르지 않으면 회원가입 버튼이 활성화됩니다.
- `setIsNicknameAvailable(false);` 코드를 추가하여 중복검사 전까지는 비활성화하게 바꿨습니다.

<br />

## :: 기타 질문 및 특이 사항

-
-
