### PR TITLE
[feat] url에서 appointment id 값 가져오는 방식 변경

### DIFF
--- a/app/user/appointments/[id]/vote-place/page.tsx
+++ b/app/user/appointments/[id]/vote-place/page.tsx
@@ -2,7 +2,7 @@
 
 import styles from "./votePlace.module.scss";
 import Button from "@/components/button/Button";
-import { usePathname } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { FaMapMarkerAlt } from "react-icons/fa";
 
@@ -12,8 +12,9 @@ interface Place {
 }
 
 const VotePlacePage: React.FC = () => {
-  const pathname = usePathname();
-  const id = pathname.split("/").slice(-2, -1)[0]; // 경로에서 ID 추출
+  const router = useRouter(); // useRouter 훅 사용 -> router.push로 페이지 이동을위해 사용
+  const params = useParams(); // URL에서 ID 추출
+  const id = params.id as string; // ID값 추출
 
   const places: Place[] = [
     { place: "홍대입구", place_url: "https://naver.me/xEABuNEP" },
@@ -29,7 +30,8 @@ const VotePlacePage: React.FC = () => {
   };
   const handleSubmit = () => {
     if (selectedPlace) {
-      alert(`${selectedPlace}${id}`);
+      alert(`투표가 완료 되었습니다.`);
+      router.push(`/user/appointments/${id}/vote-result`);
     } else {
       alert("장소를 선택해주세요.");
     }

--- a/app/user/appointments/[id]/vote-result/page.tsx
+++ b/app/user/appointments/[id]/vote-result/page.tsx
@@ -4,8 +4,12 @@ import styles from "./voteResult.module.scss";
 import TimeResult from "./components/TimeResult";
 import PlaceResult from "./components/PlaceResult";
 import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
 
 const VoteResultPage = () => {
+  const router = useRouter(); // useRouter 훅 사용 -> router.push로 페이지 이동을위해 사용
+  const params = useParams(); // URL에서 ID 추출
+  const id = params.id as string; // ID값 추출
   const [page, setPage] = useState(1);
 
   const [resultData, setResultData] = useState({
@@ -102,7 +106,11 @@ const VoteResultPage = () => {
         <PlaceResult placeProps={resultData.place} />
       )}
       <div className={styles.wrapButton}>
-        <Button text="약속 확정하러 가기" size="lg" />
+        <Button
+          text="약속 확정하러 가기"
+          size="lg"
+          onClick={() => router.push(`/user/appointments/${id}/confirm`)}
+        />
       </div>
     </div>
   );

--- a/app/user/appointments/[id]/vote-time/page.tsx
+++ b/app/user/appointments/[id]/vote-time/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, use } from "react";
 import styles from "./voteTime.module.scss";
 import Button from "@/components/button/Button";
-import { usePathname, useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 interface TimeRange {
   start_time: string; // "2025-01-02 12:00:00"
@@ -12,9 +12,8 @@ interface TimeRange {
 
 const VoteTimePage: React.FC = () => {
   const router = useRouter(); // useRouter 훅 사용 -> router.push로 페이지 이동을위해 사용
-
-  const pathname = usePathname();
-  const id = pathname.split("/").slice(-2, -1)[0]; // 경로에서 ID 추출
+  const params = useParams(); // URL에서 ID 추출
+  const id = params.id as string; // ID값 추출
 
   const timeRange: TimeRange = {
     start_time: "2025-01-01 00:00:00",


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- url에서 appointments id값 가져오는 방식 변경
- 기존방식은 url을 직접 불러와 문자열에서 id값을 찾아내는 방식이었지만 이 방법은 배포 후 도메인이 변경되는 파싱하는 코드를 수정해야함 따라서 id 값을 불러오는 방식을 다음과 같이 변경하였다.

기존 방법
```tsx
const pathname = usePathname();
const id = pathname.split("/").slice(-2, -1)[0]; // 경로에서 ID 추출
```

변경된 방법
```tsx
const params = useParams(); // URL에서 ID 추출
const id = params.id as string; // ID값 추출
```

<br />

## :: 기타 질문 및 특이 사항

-
-
