### PR TITLE
[feat] 카카오 로그인 기능 구현

### DIFF
--- a/app/(anon)/login/components/KakaoLogin.tsx
+++ b/app/(anon)/login/components/KakaoLogin.tsx
@@ -4,9 +4,26 @@ import styles from "./KakaoLogin.module.scss";
 import Image from "next/image";
 
 const KakaoLogin = () => {
+  const handleGetKakaoLoginUrl = async () => {
+    try {
+      const response = await fetch("api/auth/kakao-login-url");
+      const { loginUrl } = await response.json();
+      if (loginUrl) {
+        window.location.href = loginUrl;
+      } else {
+        console.error("로그인 URL이 없습니다.");
+      }
+    } catch (error) {
+      console.error("카카오 로그인 URL 요청 실패:", error);
+    }
+  };
+
   return (
     <div className={styles["kakaoLoginContainer"]}>
-      <button className={styles["kakaoLoginBtn"]}>
+      <button
+        className={styles["kakaoLoginBtn"]}
+        onClick={handleGetKakaoLoginUrl}
+      >
         <Image
           src={"/images/logos/kakao-logo.svg"}
           alt="카카오 로고"

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,123 @@
+import { LoginUsecase } from "@/application/usecases/auth/LoginUsecase";
+import { SignUpUsecase } from "@/application/usecases/auth/SignUpUseCase";
+import { SbAuthRepository } from "@/infrastructure/repositories/SbAuthRepository";
+import { SbUserRepository } from "@/infrastructure/repositories/SbUserRepository";
+import { NextResponse } from "next/server";
+import { KakaoLoginUsecase } from "@/application/usecases/auth/KakaoLoginUsecase";
+import { SbUserEmojiRepository } from "@/infrastructure/repositories/SbUserEmojiRepository";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+
+  if (!code) {
+    return NextResponse.json(
+      { error: "Authorization code is missing" },
+      { status: 400 }
+    );
+  }
+
+  const clientId = process.env.KAKAO_CLIENT_ID!;
+  const clientSecret = process.env.KAKAO_CLIENT_SECRET!;
+  const redirectUri = process.env.KAKAO_REDIRECT_URI!;
+
+  try {
+    const tokenResponse = await fetch("https://kauth.kakao.com/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+        code,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      console.error(
+        "Failed to fetch access token:",
+        await tokenResponse.text()
+      );
+
+      return NextResponse.json(
+        { error: "Failed to fetch access token" },
+        { status: 400 }
+      );
+    }
+
+    const tokenData = await tokenResponse.json();
+    const accessToken = tokenData.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Access token not found" },
+        { status: 400 }
+      );
+    }
+
+    // access_token을 사용하여 카카오 API에서 사용자 정보 가져오기
+    const userResponse = await fetch("https://kapi.kakao.com/v2/user/me", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    const userData = await userResponse.json();
+
+    const { email } = userData.kakao_account || {};
+    const nickname = email.split("@")[0];
+    if (!email) {
+      return NextResponse.json(
+        { error: "Failed to fetch user email" },
+        { status: 400 }
+      );
+    }
+
+    const userRepository = new SbUserRepository();
+    const userEmojiRepository = new SbUserEmojiRepository();
+    const authRepository = new SbAuthRepository();
+    const signupUsecase = new SignUpUsecase(
+      userRepository,
+      userEmojiRepository
+    );
+    const loginUsecase = new LoginUsecase(authRepository);
+
+    const kakaoLoginUsecase = new KakaoLoginUsecase(
+      signupUsecase,
+      loginUsecase
+    );
+
+    // 카카오 로그인 후 이메일로 유저가 없다면 회원가입 진행
+    try {
+      const newUser = await kakaoLoginUsecase.execute(email, nickname);
+      // 테스트 용 나중에 삭제
+      //  process.env.NODE_ENV !== "production"  배포할때는 이렇게
+      const isLocalhost =
+        process.env.NODE_ENV !== "production" ||
+        new URL(request.url).hostname === "localhost";
+      const response = NextResponse.redirect(
+        "http://localhost:3000/user/appointments"
+      );
+      response.cookies.set("token", accessToken, {
+        httpOnly: true,
+        secure: isLocalhost,
+        sameSite: "strict",
+        maxAge: 60 * 60 * 24 * 7,
+      });
+
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  } catch (error) {
+    console.error("Error during Kakao OAuth process:", error);
+    return NextResponse.json(
+      { error: "Error during Kakao OAuth process" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/kakao-login-url/route.ts
+++ b/app/api/auth/kakao-login-url/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const clientId = process.env.KAKAO_CLIENT_ID!;
+    const redirectUri = process.env.KAKAO_REDIRECT_URI!;
+    const encodedRedirectUri = encodeURIComponent(redirectUri);
+
+    const loginUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodedRedirectUri}`;
+    return NextResponse.json({ loginUrl });
+  } catch (error) {
+    return NextResponse.error(error);
+  }
+}

--- a/application/usecases/auth/KakaoLoginUsecase.ts
+++ b/application/usecases/auth/KakaoLoginUsecase.ts
@@ -1,0 +1,24 @@
+import { SignUpUsecase } from "./SignUpUseCase";
+import { LoginUsecase } from "./LoginUsecase";
+
+export class KakaoLoginUsecase {
+  constructor(
+    private signUpUsecase: SignUpUsecase,
+    private loginUsecase: LoginUsecase
+  ) {}
+
+  async execute(email: string, nickname: string) {
+    try {
+      await this.signUpUsecase.execute(email, "defaulPassword", nickname);
+
+      const userData = await this.loginUsecase.execute(
+        email,
+        "defaultPassword"
+      );
+
+      return userData;
+    } catch (error) {
+      console.log(error);
+    }
+  }
+}

--- a/application/usecases/auth/SignUpUseCase.ts
+++ b/application/usecases/auth/SignUpUseCase.ts
@@ -13,12 +13,16 @@ export class SignUpUsecase {
       throw new Error("이미 사용중인 이메일 입니다.");
     }
 
+    const uniqueNickname = await this.userRepository.generateUniqueNickname(
+      nickname
+    );
+
     const emoji = await this.UserEmojiRepository.createUserRandomEmoji();
 
     const userWithToken = await this.userRepository.createUser(
       user_email,
       password,
-      nickname,
+      uniqueNickname,
       emoji
     );
 

--- a/domain/repositories/UserRepository.ts
+++ b/domain/repositories/UserRepository.ts
@@ -9,4 +9,5 @@ export interface UserRepository {
   ): Promise<Omit<User, "password">>;
   findUserByEmail(user_email: string): Promise<Omit<User, "password"> | null>;
   findUserByNickname(nickname: string): Promise<boolean>;
+  generateUniqueNickname(baseNickname: string): Promise<string>;
 }

--- a/infrastructure/repositories/SbUserRepository.ts
+++ b/infrastructure/repositories/SbUserRepository.ts
@@ -70,4 +70,19 @@ export class SbUserRepository implements UserRepository {
 
     return !!user;
   }
+
+  async generateUniqueNickname(baseNickname: string): Promise<string> {
+    let newNickname = baseNickname;
+    let isUnique = await this.findUserByNickname(newNickname);
+
+    let counter = 1;
+
+    while (isUnique) {
+      newNickname = `${baseNickname}${counter}`;
+      isUnique = await this.findUserByNickname(newNickname);
+      counter++;
+    }
+
+    return newNickname;
+  }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 카카오 로그인 기능 구현
- 실행 흐름 카카오 로그인 버튼 클릭 -> 카카오 로그인 페이지로 리디렉션 -> 사용자가 로그인 성공 시 -> 콜백 URI에 사용자 인가 코드를 붙여서 전달해 줍니다. -> 서버에서 인가 코드를 카카오 API에 전송해 해당 사용자 access_token을 받습니다. 서버에서 카카오 API에 access_token을 가지고 해당 사용자에 대한 정보를 받습니다. -> 정보를 가지고 사용자가 supabase에 없다면 회원가입 처리 및 로그인을 실행합니다. 사용자가 있다면 로그인 합니다. 토큰은 쿠키로 저장했습니다.
-

<br />

## :: 기타 질문 및 특이 사항

- 처음에 SDK 및 signinWithIdToken을 활용한 로그인을 구현하다가 자꾸 카카오에서 주는 사용자 id_token과 supabase에 전달하는 id_token이 다르다며 오류가 생겨,,, 해결하지 못하고,, 일단 siginOAuth도 사용하지 않고 구현하였습니다.
-
