### PR TITLE
[feat] 방장 유무에따라 버튼 다르게 랜더링하는 기능 추가

### DIFF
--- a/app/user/appointments/[id]/vote-result/page.tsx
+++ b/app/user/appointments/[id]/vote-result/page.tsx
@@ -6,6 +6,7 @@ import PlaceResult from "./components/PlaceResult";
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import ArrowHeader from "@/components/header/ArrowHeader";
+import { getUserIdClient } from "@/utils/supabase/client";
 
 interface TimeVoteResult {
   start_time: string | null;
@@ -27,6 +28,7 @@ interface PlaceVoteResult {
 }
 
 interface VoteResultType {
+  ownerId: string;
   time: TimeVoteResult;
   place: PlaceVoteResult;
 }
@@ -38,6 +40,7 @@ const VoteResultPage = () => {
   const [page, setPage] = useState(1);
 
   const [resultData, setResultData] = useState<VoteResultType | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
 
   // ✅ API 호출하여 투표 결과 가져오기
   useEffect(() => {
@@ -61,6 +64,22 @@ const VoteResultPage = () => {
 
     fetchVoteResult();
   }, [id]);
+  useEffect(() => {
+    const fetchUserId = async () => {
+      try {
+        const user = await getUserIdClient();
+        if (!user) {
+          alert("❌ 로그인이 필요합니다. 로그인 페이지로 이동합니다.");
+          router.push("/login");
+          return;
+        }
+        setUserId(user);
+      } catch (error) {
+        console.error("❌ 유저 정보 가져오기 실패:", error);
+      }
+    };
+    fetchUserId();
+  }, []);
 
   if (!resultData) return <p>로딩 중...</p>;
 
@@ -106,11 +125,19 @@ const VoteResultPage = () => {
         )}
 
         <div className={styles.wrapButton}>
-          <Button
-            text="약속 확정하러 가기"
-            size="lg"
-            onClick={() => router.push(`/user/appointments/${id}/confirm`)}
-          />
+          {resultData.ownerId === userId ? (
+            <Button
+              text="약속 확정하러 가기"
+              size="lg"
+              onClick={() => router.push(`/user/appointments/${id}/confirm`)}
+            />
+          ) : (
+            <Button
+              text="홈으로 가기"
+              size="lg"
+              onClick={() => router.push(`/user/appointments`)}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/application/usecases/vote/DfGetVoteResultUsecase.ts
+++ b/application/usecases/vote/DfGetVoteResultUsecase.ts
@@ -54,11 +54,12 @@ export class DfGetVoteResultUseCase {
       })
     );
 
-    // ✅ 6. 약속 정보에서 start_time, end_time 가져오기 위함
+    // ✅ 6. 약속 정보에서 start_time, end_time 가져오기 위함 , owner_id(방장id)를 가져옴
     const appointmentInfo = await this.appointmentRepo.findById(appointmentId);
 
     // ✅ 7. 최종 결과 데이터 반환
     return {
+      ownerId: appointmentInfo?.owner_id,
       time: {
         start_time: appointmentInfo ? appointmentInfo.start_time : null,
         end_time: appointmentInfo ? appointmentInfo.end_time : null,


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- DfGetVoteResultUsecase.ts에서 약속 정보에서 start_time, end_time을 가져오는 김에 owner_id도 같이 가져와서 response로 전달
- 로그인된 유저id와 owner_id값을 비교해서 방장이면 확정페이지로 이동하는 버튼으로 렌더링,아니라면 홈으로 가는 버튼이 랜더링 되게 만듦

<br />

## :: 기타 질문 및 특이 사항

-
-
