### PR TITLE
[feat] route에서 하던 time-> time_id로 바꾸는 로직을 usecase에서 하도록 변경

### DIFF
--- a/app/api/user/appointments/[id]/vote/route.ts
+++ b/app/api/user/appointments/[id]/vote/route.ts
@@ -4,7 +4,6 @@ import { SbPlaceVoteUserRepository } from "@/infrastructure/repositories/SbPlace
 import { DfSubmitVoteUsecase } from "@/application/usecases/vote/DfSubmitVoteUsecase";
 import { SbTimeVoteRepository } from "@/infrastructure/repositories/SbTimeVoteRepository";
 import { SbMemberRepository } from "@/infrastructure/repositories/SbMemberRepository";
-import { TimeVoteDto } from "@/application/usecases/vote/dto/VoteDto";
 
 export async function POST(
   request: NextRequest,
@@ -23,49 +22,12 @@ export async function POST(
       );
     }
 
-    const timeVoteRepo = new SbTimeVoteRepository();
-    const voteUsecase = new DfSubmitVoteUsecase(
+    const submitVoteUsecase = new DfSubmitVoteUsecase(
       new SbTimeVoteUserRepository(),
       new SbPlaceVoteUserRepository(),
-      new SbMemberRepository()
+      new SbMemberRepository(),
+      new SbTimeVoteRepository()
     );
-
-    // ✅ page에서 받은 time(YYYY-MM-DD HH:MM:SS)이 time_vote테이블에 존재하면 time_id반환 없으면 null반환
-    const existingTimeVotes = await Promise.all(
-      timeVotes.map(async (vote: { time: string }) => {
-        const existingTimeId = await timeVoteRepo.findTimeIdByTimestamp(
-          appointmentId,
-          vote.time
-        );
-        return existingTimeId ? { timeId: existingTimeId } : null;
-      })
-    );
-
-    // ✅ page에서 받은 time들 가운데 time_id가 없는 것듯은 nuwTimes에 저장
-    const newTimes = timeVotes.filter(
-      (_: { time: string }, index: number) => !existingTimeVotes[index]
-    );
-
-    // ✅ 새로운 시간들을 DB에 추가하고 ID 리스트 가져오기
-    const newTimeIds = await timeVoteRepo.createTimeVotes(
-      appointmentId,
-      newTimes.map((vote: { time: string }) => vote.time)
-    );
-
-    // ✅ null 값을 newTimeIds에서 가져올 때 올바르게 매핑
-    const processedTimeVotes: TimeVoteDto[] = existingTimeVotes
-      .map((vote, index) => {
-        if (vote) {
-          return vote; // ✅ 기존 time_id가 있으면 그대로 사용
-        } else {
-          const newTimeId = newTimeIds.shift();
-          if (!newTimeId) {
-            throw new Error("새로운 timeId 매핑 중 오류 발생"); // ✅ 예외 처리 추가
-          }
-          return { timeId: newTimeId }; // ✅ 새로 추가한 timeId 매핑
-        }
-      })
-      .filter((vote): vote is TimeVoteDto => vote !== null); // ✅ `null` 필터링
 
     // ✅ placeVotes 유효성 검사
     if (!placeVotes || placeVotes.length === 0 || !placeVotes[0]?.placeId) {
@@ -77,10 +39,10 @@ export async function POST(
 
     // ✅ 투표 저장 실행 (서버에서 발생하는 오류를 catch하기 위함)
     try {
-      await voteUsecase.execute({
+      await submitVoteUsecase.execute({
         userId,
         appointmentId,
-        timeVotes: processedTimeVotes,
+        timeVotes,
         placeVotes,
       });
     } catch (voteError) {

--- a/application/usecases/vote/DfSubmitVoteUsecase.ts
+++ b/application/usecases/vote/DfSubmitVoteUsecase.ts
@@ -1,13 +1,20 @@
 import { TimeVoteUserRepository } from "@/domain/repositories/TimeVoteUserRepository";
 import { PlaceVoteUserRepository } from "@/domain/repositories/PlaceVoteUserRepository";
-import { PlaceVoteDto, TimeVoteDto, VoteSubmissionDto } from "./dto/VoteDto";
+import {
+  PlaceVoteDto,
+  TimeVoteDto,
+  TimeVoteInputDto,
+  VoteSubmissionDto,
+} from "./dto/VoteDto";
 import { MemberRepository } from "@/domain/repositories/MemberRepository";
+import { TimeVoteRepository } from "@/domain/repositories/TimeVoteRepository";
 
 export class DfSubmitVoteUsecase {
   constructor(
     private timeVoteUserRepo: TimeVoteUserRepository,
     private placeVoteUserRepo: PlaceVoteUserRepository,
-    private memberRepo: MemberRepository
+    private memberRepo: MemberRepository,
+    private timeVoteRepo: TimeVoteRepository
   ) {}
 
   async execute(voteData: VoteSubmissionDto): Promise<void> {
@@ -23,21 +30,55 @@ export class DfSubmitVoteUsecase {
       throw new Error("❌ 이미 투표한 사용자입니다.");
     }
 
-    // ✅ 1. 사용자가 시간 투표한 데이터 저장 (time_vote_user 테이블)
+    // ✅ 2. page에서 받은 time(YYYY-MM-DD HH:MM:SS)이 time_vote테이블에 존재하면 time_id반환 없으면 null반환
+    const timeVoteInputs: TimeVoteInputDto[] =
+      timeVotes as unknown as TimeVoteInputDto[];
+
+    const existingTimeVotes: (TimeVoteDto | null)[] = await Promise.all(
+      timeVoteInputs.map(async (vote) => {
+        const existingTimeId = await this.timeVoteRepo.findTimeIdByTimestamp(
+          appointmentId,
+          vote.time // ✅ `{ time: string }`이므로 `vote.time`만 전달
+        );
+        return existingTimeId ? { timeId: existingTimeId } : null;
+      })
+    );
+
+    // ✅ 3. page에서 받은 time들 가운데 time_id가 없는 것듯은 nuwTimes에 저장
+    const newTimes: string[] = timeVoteInputs
+      .filter((_, index) => !existingTimeVotes[index]) // ✅ `null`이 아닌 경우만 필터링
+      .map((vote) => vote.time); // ✅ 이제 `vote.time`은 반드시 `string`
+
+    // ✅ 4. 새로운 시간들을 DB에 추가하고 ID 리스트 가져오기
+    const newTimeIds = await this.timeVoteRepo.createTimeVotes(
+      appointmentId,
+      newTimes
+    );
+
+    // ✅ 5. null 값을 newTimeIds에서 가져올 때 올바르게 매핑
+    let newTimeIndex = 0;
+    const processedTimeVotes: TimeVoteDto[] = existingTimeVotes.map((vote) => {
+      if (vote) return vote; // ✅ 기존 `timeId` 유지
+      const newTimeId = newTimeIds[newTimeIndex++];
+      if (!newTimeId) throw new Error("새로운 timeId 매핑 중 오류 발생"); // ✅ 예외 처리 추가
+      return { timeId: newTimeId };
+    });
+
+    // ✅ 6. 사용자가 시간 투표한 데이터 저장 (time_vote_user 테이블)
     await Promise.all(
-      timeVotes.map(async (timeVote: TimeVoteDto) => {
+      processedTimeVotes.map(async (timeVote: TimeVoteDto) => {
         await this.timeVoteUserRepo.voteForTime(userId, timeVote.timeId);
       })
     );
 
-    // ✅ 2. 사용자가 장소 투표한 데이터 저장 (place_vote_user 테이블)
+    // ✅ 7. 사용자가 장소 투표한 데이터 저장 (place_vote_user 테이블)
     await Promise.all(
       placeVotes.map(async (placeVote: PlaceVoteDto) => {
         await this.placeVoteUserRepo.voteForPlace(userId, placeVote.placeId);
       })
     );
 
-    // ✅ 4. 투표 완료 후 사용자의 `is_vote` 상태를 `true`로 업데이트
+    // ✅ 8. 투표 완료 후 사용자의 `is_vote` 상태를 `true`로 업데이트
     await this.memberRepo.updateVoteStatus(userId, appointmentId, true);
 
     console.log("📌 [DEBUG] DfSubmitVoteUsecase 완료!");

--- a/application/usecases/vote/dto/TimeVoteDto.ts
+++ b/application/usecases/vote/dto/TimeVoteDto.ts
@@ -1,4 +1,0 @@
-export interface TimeVoteDto {
-  time(appointmentId: number, time: any): unknown;
-  timeId: number; // ✅ time_vote 테이블의 id
-}

--- a/application/usecases/vote/dto/VoteDto.ts
+++ b/application/usecases/vote/dto/VoteDto.ts
@@ -1,10 +1,13 @@
 export interface TimeVoteDto {
-  time(appointmentId: number, time: any): unknown;
   timeId: number; // ✅ time_vote 테이블의 id
 }
 
 export interface PlaceVoteDto {
   placeId: number; // ✅ place_vote 테이블의 id
+}
+
+export interface TimeVoteInputDto {
+  time: string;
 }
 
 export interface VoteSubmissionDto {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- route에서 하던 time-> time_id로 바꾸는 로직을 usecase에서 하도록 변경
```ts
// ✅ 1. page에서 받은 time(YYYY-MM-DD HH:MM:SS)이 time_vote테이블에 존재하면 time_id반환 없으면 null반환
    const timeVoteInputs: TimeVoteInputDto[] =
      timeVotes as unknown as TimeVoteInputDto[];

    const existingTimeVotes: (TimeVoteDto | null)[] = await Promise.all(
      timeVoteInputs.map(async (vote) => {
        const existingTimeId = await this.timeVoteRepo.findTimeIdByTimestamp(
          appointmentId,
          vote.time // ✅ `{ time: string }`이므로 `vote.time`만 전달
        );
        return existingTimeId ? { timeId: existingTimeId } : null;
      })
    );

    // ✅ 2. page에서 받은 time들 가운데 time_id가 없는 것듯은 nuwTimes에 저장
    const newTimes: string[] = timeVoteInputs
      .filter((_, index) => !existingTimeVotes[index]) // ✅ `null`이 아닌 경우만 필터링
      .map((vote) => vote.time); // ✅ 이제 `vote.time`은 반드시 `string`

    // ✅ 3. 새로운 시간들을 DB에 추가하고 ID 리스트 가져오기
    const newTimeIds = await this.timeVoteRepo.createTimeVotes(
      appointmentId,
      newTimes
    );

    // ✅ 4. null 값을 newTimeIds에서 가져올 때 올바르게 매핑
    let newTimeIndex = 0;
    const processedTimeVotes: TimeVoteDto[] = existingTimeVotes.map((vote) => {
      if (vote) return vote; // ✅ 기존 `timeId` 유지
      const newTimeId = newTimeIds[newTimeIndex++];
      if (!newTimeId) throw new Error("새로운 timeId 매핑 중 오류 발생"); // ✅ 예외 처리 추가
      return { timeId: newTimeId };
    });

    // ✅ 5. 사용자가 시간 투표한 데이터 저장 (time_vote_user 테이블)
    await Promise.all(
      processedTimeVotes.map(async (timeVote: TimeVoteDto) => {
        await this.timeVoteUserRepo.voteForTime(userId, timeVote.timeId);
      })
    );
```


