### PR TITLE
[feat] admin페이지- 약속관리기능 추가

### DIFF
--- a/app/admin/appointments/appointments.module.scss
+++ b/app/admin/appointments/appointments.module.scss
@@ -3,7 +3,7 @@
 
   h2 {
     font-size: 24px;
-    margin-bottom: 15px;
+    margin-bottom: 16px;
   }
 
   .filterContainer {
@@ -20,57 +20,75 @@
       padding: 5px;
       border: 1px solid #ccc;
       border-radius: 5px;
+      cursor: pointer;
     }
   }
 
-  .table {
+  .tableContainer {
     width: 100%;
-    border-collapse: collapse;
-    margin-top: 10px;
+    max-height: 500px; // ✅ 너무 길어지지 않도록 제한
+    overflow-y: auto; // ✅ 세로 스크롤 추가
+    border-radius: 8px;
 
-    th,
-    td {
-      border: 1px solid #ddd;
-      padding: 10px;
-      text-align: center;
-    }
+    .table {
+      border-collapse: collapse;
+      margin-top: 10px;
 
-    th {
-      background-color: #f4f4f4;
-      font-weight: bold;
-    }
-
-    .link {
-      cursor: pointer;
-      color: #0070f3;
-      &:hover {
-        text-decoration: underline;
+      th,
+      td {
+        padding: 10px;
+        border: 1px solid #ddd;
+        text-align: center;
+        white-space: nowrap; // ✅ 줄바꿈 방지
+        overflow: hidden;
+        text-overflow: ellipsis; // ✅ 긴 텍스트 `...` 처리
+        max-width: 140px; // ✅ 셀 너비 제한
       }
-    }
 
-    .voting {
-      color: #007bff;
-      font-weight: bold;
-    }
+      th {
+        background-color: #f8f8f8;
+        font-weight: bold;
+      }
+      tr:nth-child(even) {
+        background-color: #f9f9f9;
+      }
 
-    .upcoming {
-      color: #28a745;
-      font-weight: bold;
-    }
+      .link {
+        cursor: pointer;
+        color: #000;
+        &:hover {
+          color: #0070f3;
+        }
+      }
 
-    .finished {
-      color: #dc3545;
-      font-weight: bold;
-    }
+      .voting {
+        color: #007bff;
+        font-weight: bold;
+      }
 
-    .deleteButton {
-      background-color: #dc3545;
-      color: white;
-      border: none;
-      padding: 5px 10px;
-      cursor: pointer;
-      &:hover {
-        background-color: #c82333;
+      .upcoming {
+        color: #28a745;
+        font-weight: bold;
+      }
+
+      .finished {
+        color: #dc3545;
+        font-weight: bold;
+      }
+
+      .deleteButton {
+        padding: 6px 12px;
+        background-color: #dc3545;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        transition: background-color 0.2s;
+
+        &:hover {
+          background-color: #a71d2a;
+        }
       }
     }
   }

--- a/app/admin/layout.module.scss
+++ b/app/admin/layout.module.scss
@@ -3,7 +3,7 @@
   .title {
     font-size: 24px;
     font-weight: bold;
-    margin-bottom: 16px;
+    margin: 20px 0;
   }
   .nav {
     display: flex;
@@ -13,9 +13,9 @@
     margin-bottom: 16px;
     .tab {
       width: 30%;
-      height: 30px;
+      height: 40px;
       text-align: center;
-      line-height: 200%;
+      line-height: 250%;
       border-radius: 4px;
       text-decoration: none;
       background-color: #f0f0f0;

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -103,9 +103,9 @@ export default function UsersPage() {
             {filteredUsers.length > 0 ? (
               filteredUsers.map((user) => (
                 <tr key={user.id}>
-                  <td>{user.id}</td>
-                  <td>{user.email}</td>
-                  <td>{user.nickname}</td>
+                  <td title={user.id}>{user.id}</td>
+                  <td title={user.email}>{user.email}</td>
+                  <td title={user.nickname}>{user.nickname}</td>
                   <td>
                     <button
                       className={styles.deleteButton}

--- a/app/admin/users/users.module.scss
+++ b/app/admin/users/users.module.scss
@@ -45,47 +45,45 @@
   .tableContainer {
     max-height: 500px; // ✅ 너무 길어지지 않도록 제한
     overflow-y: auto; // ✅ 세로 스크롤 추가
-    border: 1px solid #ddd;
     border-radius: 8px;
-  }
+    .table {
+      width: 100%;
+      border-collapse: collapse;
 
-  .table {
-    width: 100%;
-    border-collapse: collapse;
+      th,
+      td {
+        padding: 10px;
+        border: 1px solid #ddd;
+        text-align: center;
+        white-space: nowrap; // ✅ 줄바꿈 방지
+        overflow: hidden;
+        text-overflow: ellipsis; // ✅ 너무 긴 텍스트 `...` 처리
+        max-width: 110px; // ✅ 셀 너비 제한
+      }
 
-    th,
-    td {
-      padding: 10px;
-      border: 1px solid #ddd;
-      text-align: left;
-      white-space: nowrap; // ✅ 줄바꿈 방지
-      overflow: hidden;
-      text-overflow: ellipsis; // ✅ 너무 긴 텍스트 `...` 처리
-      max-width: 110px; // ✅ 셀 너비 제한
+      th {
+        background-color: #f8f8f8;
+        font-weight: bold;
+      }
+
+      tr:nth-child(even) {
+        background-color: #f9f9f9;
+      }
     }
 
-    th {
-      background-color: #f8f8f8;
-      font-weight: bold;
-    }
+    .deleteButton {
+      padding: 6px 12px;
+      background-color: #dc3545;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      transition: background-color 0.2s;
 
-    tr:nth-child(even) {
-      background-color: #f9f9f9;
-    }
-  }
-
-  .deleteButton {
-    padding: 6px 12px;
-    background-color: #dc3545;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    transition: background-color 0.2s;
-
-    &:hover {
-      background-color: #a71d2a;
+      &:hover {
+        background-color: #a71d2a;
+      }
     }
   }
 }

--- a/app/api/admin/appointments/[id]/route.ts
+++ b/app/api/admin/appointments/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SbAppointmentRepository } from "@/infrastructure/repositories/SbAppointmentRepository";
+import { DfDeleteAppointmentUsecase } from "@/application/usecases/appointment/DfDeleteAppointmentUsecase";
+
+// ✅ DELETE: 약속 삭제
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "약속 ID가 없습니다." },
+        { status: 400 }
+      );
+    }
+
+    const appointmentRepo = new SbAppointmentRepository();
+    const deleteAppointmentUsecase = new DfDeleteAppointmentUsecase(
+      appointmentRepo
+    );
+
+    const isDeleted = await deleteAppointmentUsecase.execute(id);
+
+    if (!isDeleted) {
+      return NextResponse.json({ error: "약속 삭제 실패" }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: "약속이 성공적으로 삭제되었습니다." });
+  } catch (error) {
+    console.error("❌ 약속 삭제 중 오류 발생:", error);
+    return NextResponse.json({ error: "서버 오류 발생" }, { status: 500 });
+  }
+}

--- a/app/api/admin/appointments/route.ts
+++ b/app/api/admin/appointments/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SbAppointmentRepository } from "@/infrastructure/repositories/SbAppointmentRepository";
+import { DfGetAllAppointmentsUsecase } from "@/application/usecases/appointment/DfGetAllAppointmentsUsecase";
+import { AppointmentListDto } from "@/application/usecases/appointment/dto/AppointmentListDto";
+
+// ✅ GET: 약속 목록 조회
+export async function GET(request: NextRequest) {
+  try {
+    const appointmentRepo = new SbAppointmentRepository();
+    const getAllAppointmentsUseCase = new DfGetAllAppointmentsUsecase(
+      appointmentRepo
+    );
+
+    const appointments: AppointmentListDto[] =
+      await getAllAppointmentsUseCase.execute();
+
+    return NextResponse.json(appointments);
+  } catch (error) {
+    return NextResponse.json(
+      { error: (error as any).message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/user/appointments/[id]/vote-place/page.tsx
+++ b/app/user/appointments/[id]/vote-place/page.tsx
@@ -110,7 +110,7 @@ const VotePlacePage: React.FC = () => {
               className={`${styles.placeItem} ${
                 selectedPlace === item.id ? styles.selected : ""
               }`}
-              onClick={() => handleSelect(item.id)}
+              onClick={() => item.id !== undefined && handleSelect(item.id)}
             >
               <div className={styles.itemTop}>
                 <div className={styles.placeName}>

--- a/application/usecases/appointment/DfDeleteAppointmentUsecase.ts
+++ b/application/usecases/appointment/DfDeleteAppointmentUsecase.ts
@@ -1,0 +1,9 @@
+import { AppointmentRepository } from "@/domain/repositories/AppointmentRepository";
+
+export class DfDeleteAppointmentUsecase {
+  constructor(private appointmentRepo: AppointmentRepository) {}
+
+  async execute(appointmentId: string): Promise<boolean> {
+    return await this.appointmentRepo.deleteAppointment(appointmentId);
+  }
+}

--- a/application/usecases/appointment/DfGetAllAppointmentsUsecase.ts
+++ b/application/usecases/appointment/DfGetAllAppointmentsUsecase.ts
@@ -1,0 +1,19 @@
+import { AppointmentRepository } from "@/domain/repositories/AppointmentRepository";
+import { AppointmentListDto } from "./dto/AppointmentListDto";
+
+export class DfGetAllAppointmentsUsecase {
+  constructor(private appointmentRepo: AppointmentRepository) {}
+
+  async execute(): Promise<AppointmentListDto[]> {
+    const appointments = await this.appointmentRepo.getAllAppointments();
+
+    // ✅ UseCase에서 DTO 변환
+    return appointments.map((appointment) => ({
+      id: appointment.id,
+      title: appointment.title,
+      status: appointment.status,
+      confirm_time: appointment.confirm_time,
+      created_at: appointment.created_at,
+    }));
+  }
+}

--- a/application/usecases/appointment/dto/AppointmentListDto.ts
+++ b/application/usecases/appointment/dto/AppointmentListDto.ts
@@ -1,0 +1,7 @@
+export interface AppointmentListDto {
+  id: number | undefined;
+  title: string;
+  status: string;
+  confirm_time: string | null | undefined; // 확정 시간이 없을 수도 있음
+  created_at: string | undefined;
+}

--- a/domain/repositories/AppointmentRepository.ts
+++ b/domain/repositories/AppointmentRepository.ts
@@ -22,5 +22,6 @@ export interface AppointmentRepository {
       status: string;
     }
   ): Promise<void>; // 약속 확정
-  delete(appointmentId: number): Promise<void>; // 약속 삭제
+  getAllAppointments(): Promise<Appointment[]>;
+  deleteAppointment(id: string): Promise<boolean>;
 }

--- a/infrastructure/repositories/SbAppointmentRepository.ts
+++ b/infrastructure/repositories/SbAppointmentRepository.ts
@@ -114,15 +114,40 @@ export class SbAppointmentRepository implements AppointmentRepository {
     }
   }
 
-  async delete(appointmentId: number): Promise<void> {
+  // ✅ 약속 삭제
+  async deleteAppointment(id: string): Promise<boolean> {
     const supabase = await this.getClient();
-    const { error } = await supabase
-      .from("appointment")
-      .delete()
-      .eq("id", appointmentId);
+
+    const { error } = await supabase.from("appointment").delete().eq("id", id);
 
     if (error) {
-      throw new Error(`약속 삭제 실패: ${error.message}`);
+      console.error("❌ 약속 삭제 실패:", error);
+      return false;
     }
+
+    return true;
+  }
+  // ✅ 전체 약속 조회
+  async getAllAppointments(): Promise<Appointment[]> {
+    const supabase = await this.getClient();
+
+    const { data, error } = await supabase
+      .from("appointment")
+      .select("id, title, status, confirm_time, created_at");
+
+    if (error) {
+      throw new Error("약속 목록 조회 실패");
+    }
+
+    return (data || []).map((appointment) => ({
+      id: appointment.id,
+      title: appointment.title,
+      status: appointment.status,
+      confirm_time: appointment.confirm_time,
+      created_at: appointment.created_at,
+      start_time: "",
+      end_time: "",
+      owner_id: "",
+    }));
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 약속 전체 리스트 불러오기
```ts
// ✅ 전체 약속 조회
  async getAllAppointments(): Promise<Appointment[]> {
    const supabase = await this.getClient();

    const { data, error } = await supabase
      .from("appointment")
      .select("id, title, status, confirm_time, created_at");

    if (error) {
      throw new Error("약속 목록 조회 실패");
    }

    return (data || []).map((appointment) => ({
      id: appointment.id,
      title: appointment.title,
      status: appointment.status,
      confirm_time: appointment.confirm_time,
      created_at: appointment.created_at,
      start_time: "",
      end_time: "",
      owner_id: "",
    }));
  }
```
2. 약속 삭제 기능
```ts
// ✅ 약속 삭제
  async deleteAppointment(id: string): Promise<boolean> {
    const supabase = await this.getClient();

    const { error } = await supabase.from("appointment").delete().eq("id", id);

    if (error) {
      console.error("❌ 약속 삭제 실패:", error);
      return false;
    }

    return true;
  }
```

<br />

## :: 기타 질문 및 특이 사항

-
-
