### PR TITLE
[feat] 마이 페이지 상태에 따른 개수 표시 

### DIFF
--- a/app/user/components/AppointmentCount.tsx
+++ b/app/user/components/AppointmentCount.tsx
@@ -1,11 +1,19 @@
 "use client";
 import styles from "./AppointmentCount.module.scss";
 
-const AppointmentCount = ({ color, text }: { color: string; text: string }) => {
+const AppointmentCount = ({
+  color,
+  text,
+  count,
+}: {
+  color: string;
+  text: string;
+  count: number;
+}) => {
   return (
     <div className={`${styles.appointmentContainer} ${styles[color]}`}>
       <div className={styles.spanBox}>
-        <span>7</span>
+        <span>{count}</span>
         <span>{text}</span>
       </div>
     </div>

--- a/app/user/components/MyCalendar.tsx
+++ b/app/user/components/MyCalendar.tsx
@@ -6,39 +6,19 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 
 import "./MyCalendar.scss";
 import koLocale from "@fullcalendar/core/locales/ko";
+import { getEventsStatus } from "@/utils/user/getEventsStatus";
+import { Event } from "@/types/Event";
 
-interface Event {
-  title: string;
-  start: string;
-  end: string;
-  confirm_time: string;
-  status: string;
-}
-
-const MyCalendar = () => {
+const MyCalendar = ({
+  onAppointmentsFetch,
+}: {
+  onAppointmentsFetch: (appointments: Event[]) => void;
+}) => {
   const [events, setEvents] = useState<Event[]>([]);
-
-  const getEventsStatus = (event: Event) => {
-    const startTime = event.start;
-    const confirmTime = event.confirm_time ? event.confirm_time : null;
-
-    if (event.status === "voting") {
-      return { status: "voting", color: "#64c964" };
-    }
-
-    if (event.status === "confirmed") {
-      if (confirmTime && confirmTime < startTime) {
-        return { status: "scheduled", color: "##fd8446" };
-      }
-      return { status: "confirmed", color: "#fd565f" };
-    }
-    return { status: event.status, color: "#000000" };
-  };
 
   useEffect(() => {
     const appointmentsListFetch = async () => {
       const response = await fetch("/api/user/user-appointments");
-
       const appointments = await response.json();
       const transformedEvents = appointments.map((event: Event) => {
         const { status, color } = getEventsStatus(event);
@@ -51,6 +31,7 @@ const MyCalendar = () => {
       });
 
       setEvents(transformedEvents);
+      onAppointmentsFetch(transformedEvents);
     };
 
     appointmentsListFetch();

--- a/app/user/components/UserAppointmentCount.tsx
+++ b/app/user/components/UserAppointmentCount.tsx
@@ -1,17 +1,42 @@
 "use client";
+import { Event } from "@/types/Event";
 import AppointmentCount from "./AppointmentCount";
 import styles from "./UserAppointmentCount.module.scss";
-const appointmentData = [
-  { color: "greenColor", text: "투표중" },
-  { color: "orangeColor", text: "예정" },
-  { color: "pinkColor", text: "확정" },
-];
 
-const UserAppointmentCount = () => {
+const UserAppointmentCount = ({
+  appointments = [],
+}: {
+  appointments: Event[] | null;
+}) => {
+  const votingCount =
+    appointments?.filter((appointment) => {
+      return appointment.status;
+    }).length ?? 0;
+
+  const scheduledCount =
+    appointments?.filter(
+      (appointment) => appointment.status === "scheduledCount"
+    ).length ?? 0;
+  const confirmedCount =
+    appointments?.filter(
+      (appointment) => appointment.status === "confirmedCount"
+    ).length ?? 0;
+
+  const appointmentData = [
+    { color: "greenColor", text: "투표중", count: votingCount },
+    { color: "orangeColor", text: "예정", count: scheduledCount },
+    { color: "pinkColor", text: "확정", count: confirmedCount },
+  ];
+
   return (
     <div className={styles.appointmentCountBox}>
       {appointmentData.map((item, index) => (
-        <AppointmentCount key={index} color={item.color} text={item.text} />
+        <AppointmentCount
+          key={index}
+          color={item.color}
+          text={item.text}
+          count={item.count}
+        />
       ))}
     </div>
   );

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -9,9 +9,11 @@ import UserProfile from "./components/UserProfile";
 import MyCalendar from "./components/MyCalendar";
 import IconHeader from "@/components/header/IconHeader";
 import UserAppointmentCount from "./components/UserAppointmentCount";
+import { Event } from "@/types/Event";
 
 const MyPagePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [appointments, setAppointments] = useState<Event[]>([]);
   const handleopenModal = () => setIsModalOpen(true);
   const handlecloseModal = () => setIsModalOpen(false);
 
@@ -21,10 +23,10 @@ const MyPagePage = () => {
       <div className={styles.myPagecontainer}>
         <div className={styles.profileWrapper}>
           <UserProfile />
-          <UserAppointmentCount />
+          <UserAppointmentCount appointments={appointments} />
         </div>
         <div className={styles.calendarWrapper}>
-          <MyCalendar />
+          <MyCalendar onAppointmentsFetch={setAppointments} />
         </div>
 
         <div className={styles.deleteAccountButton}>

--- a/types/Event.ts
+++ b/types/Event.ts
@@ -1,0 +1,7 @@
+export interface Event {
+  title: string;
+  start: string;
+  end: string;
+  confirm_time: string;
+  status: string;
+}

--- a/utils/user/getEventsStatus.ts
+++ b/utils/user/getEventsStatus.ts
@@ -1,0 +1,18 @@
+import { Event } from "@/types/Event";
+
+export const getEventsStatus = (event: Event) => {
+  const startTime = event.start;
+  const confirmTime = event.confirm_time ? event.confirm_time : null;
+
+  if (event.status === "voting") {
+    return { status: "voting", color: "#64c964" };
+  }
+
+  if (event.status === "confirmed") {
+    if (confirmTime && confirmTime < startTime) {
+      return { status: "scheduled", color: "##fd8446" };
+    }
+    return { status: "confirmed", color: "#fd565f" };
+  }
+  return { status: event.status, color: "#000000" };
+};


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- Event 타입을 자주 사용하여 분리하여 import 하여 사용합니다. `경로` : `/types/Event.ts`
- getEventsStatus 함수도 분리하여 import 하여 하용합니다. `경로` : `/utils/user`
- getEventsStatus : 약속을 받고, 해당 약속에 시작 시간과 확정 시간을 뽑습니다.
각자 변수에 startTime, confirmTime 에 넣고 약속 상태가 voting이라면 { status: "voting", color: "#64c964" } , 확정 시간이 시작 시간보다 이전이면 { status: "scheduled", color: "##fd8446" }, 
그 외에 시간이라면 { status: "confirmed", color: "#fd565f" } 이 조건 모두 아니라면  { status: event.status, color: "#000000" }
반환합니다.

- 마이페이지에서 자식 컴포넌트인 `MyCalendar` 컴포넌트에서 약속 리스트를 fetch로 받아옵니다. 받은 후 약속들을 부모컴포넌트에 전달을 해줍니다. `onAppointmentsFetch(transformedEvents)` 부모 컴포넌트는 해당 데이터를 `const [appointments, setAppointments] = useState<Event[]>([]);` 에 저장합니다. 형제 컴포넌트인 `UserAppointmentCount` 에 이 데이터를 전달해줍니다. 해당 컴포넌트는 데이터를 받은 후 해당 status별로 필터링을 하여 개수를 카운트 합니다. 다음 
```
 const appointmentData = [
    { color: "greenColor", text: "투표중", count: votingCount },
    { color: "orangeColor", text: "예정", count: scheduledCount },
    { color: "pinkColor", text: "확정", count: confirmedCount },
  ];
```

에 각각 저장을 하고 해당 데이터를 map을 사용하여 최종 UI가 생성됩니다. 

- 마이페이지에서 그냥 약속 리스트를 fetch하여 각각 props로 전달해주는 방법과 , `MyCalendar`에서 fetch를 하여 부모컴포넌트에게 전달하기 중 `MyCalendar에서 fetch`를 선택하였습니다. 이유는 통코드로 코딩을 했다면 마이페이지에서 하는게 맞지만 컴포넌트를 나눴으니 역할을 나눈거라 해당 컴포넌트에서 데이터를 불러오기로 정했습니다.

<br />

## :: 기타 질문 및 특이 사항

-
-
