### PR TITLE
[feat] page.tsx에서 하던 로그인 검사-> layout에 context로 검사, admin page 헤더추가

### DIFF
--- a/app/admin/appointments/appointments.module.scss
+++ b/app/admin/appointments/appointments.module.scss
@@ -36,13 +36,14 @@
 
       th,
       td {
+        width: 100%;
+        max-width: 116px; // ✅ 셀 너비 제한
         padding: 10px;
         border: 1px solid #ddd;
         text-align: center;
         white-space: nowrap; // ✅ 줄바꿈 방지
         overflow: hidden;
         text-overflow: ellipsis; // ✅ 긴 텍스트 `...` 처리
-        max-width: 140px; // ✅ 셀 너비 제한
       }
 
       th {

--- a/app/admin/images/images.module.scss
+++ b/app/admin/images/images.module.scss
@@ -28,8 +28,7 @@
       width: 100%;
       img {
         width: 100%;
-        height: auto;
-        max-height: 150px;
+        height: 150px;
         border-radius: 5px;
         object-fit: cover;
       }

--- a/app/admin/layout.module.scss
+++ b/app/admin/layout.module.scss
@@ -1,33 +1,36 @@
 .adminContainer {
-  padding: 24px;
   .title {
-    font-size: 24px;
+    color: #fff;
+    font-size: 20px;
     font-weight: bold;
-    margin: 20px 0;
+    font-family: var(--font-sub);
   }
-  .nav {
-    display: flex;
-    justify-content: space-between;
-    border-bottom: 2px solid #ddd;
-    padding-bottom: 8px;
-    margin-bottom: 16px;
-    .tab {
-      width: 30%;
-      height: 40px;
-      text-align: center;
-      line-height: 250%;
-      border-radius: 4px;
-      text-decoration: none;
-      background-color: #f0f0f0;
-      color: #333;
-      &:hover {
+  .mainBox {
+    padding: 24px;
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      border-bottom: 2px solid #ddd;
+      padding-bottom: 8px;
+      margin-bottom: 16px;
+      .tab {
+        width: 30%;
+        height: 40px;
+        text-align: center;
+        line-height: 250%;
+        border-radius: 4px;
+        text-decoration: none;
+        background-color: #f0f0f0;
+        color: #333;
+        &:hover {
+          background-color: #007bff;
+          color: white;
+        }
+      }
+      .active {
         background-color: #007bff;
         color: white;
       }
-    }
-    .active {
-      background-color: #007bff;
-      color: white;
     }
   }
 }

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import styles from "./layout.module.scss";
+import Header from "@/components/header/components/Header";
 
 const tabs = [
   { name: "유저 관리", href: "/admin/users" },
@@ -18,22 +19,29 @@ export default function AdminLayout({
   const pathname = usePathname();
 
   return (
-    <div className={styles.adminContainer}>
-      <h1 className={styles.title}>시스템 관리 페이지</h1>
-      <div className={styles.nav}>
-        {tabs.map((tab) => (
-          <Link
-            key={tab.href}
-            href={tab.href}
-            className={`${styles.tab} ${
-              pathname === tab.href ? styles.active : ""
-            }`}
-          >
-            {tab.name}
-          </Link>
-        ))}
+    <>
+      <div className={styles.adminContainer}>
+        <Header
+          showUsername={false}
+          children={<h1 className={styles.title}>ADMIN</h1>}
+        />
+        <div className={styles.mainBox}>
+          <div className={styles.nav}>
+            {tabs.map((tab) => (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                className={`${styles.tab} ${
+                  pathname === tab.href ? styles.active : ""
+                }`}
+              >
+                {tab.name}
+              </Link>
+            ))}
+          </div>
+          <div>{children}</div>
+        </div>
       </div>
-      <div>{children}</div>
-    </div>
+    </>
   );
 }

--- a/app/user/appointments/[id]/confirm/complete/page.tsx
+++ b/app/user/appointments/[id]/confirm/complete/page.tsx
@@ -16,6 +16,7 @@ const CompletePage = () => {
   const [isCopiedLink, setIsCopiedLink] = useState(false);
   const [isCopiedRoomId, setIsCopiedRoomId] = useState(false);
 
+  // 복사 함수, pc환경에서만 작동
   // const handleCopyInviteLink = async () => {
   //   try {
   //     await navigator.clipboard.writeText(

--- a/app/user/appointments/[id]/confirm/page.tsx
+++ b/app/user/appointments/[id]/confirm/page.tsx
@@ -25,23 +25,6 @@ const ConfirmPage = () => {
   const [confirmPlace, setConfirmPlace] = useState("");
   const [isModalOpen, setModalOpen] = useState(false);
 
-  // 로그인 상태 확인
-  useEffect(() => {
-    const fetchUserId = async () => {
-      try {
-        const user = await getUserIdClient();
-        if (!user) {
-          alert("❌ 로그인이 필요합니다. 로그인 페이지로 이동합니다.");
-          router.push("/login");
-          return;
-        }
-      } catch (error) {
-        console.error("❌ 유저 정보 가져오기 실패:", error);
-      }
-    };
-    fetchUserId();
-  }, []);
-
   // ✅ 1. 장소 목록을 API에서 가져오기
   useEffect(() => {
     const fetchPlaces = async () => {

--- a/app/user/appointments/[id]/vote-place/page.tsx
+++ b/app/user/appointments/[id]/vote-place/page.tsx
@@ -6,9 +6,9 @@ import { FaMapMarkerAlt } from "react-icons/fa";
 import styles from "./votePlace.module.scss";
 import Button from "@/components/button/Button";
 import { useTimeVote } from "@/context/TimeVoteContext";
-import { getUserIdClient } from "@/utils/supabase/client"; // ✅ `userId` 가져오는 함수
 import { PlaceVote } from "@/domain/entities/PlaceVote";
 import Loading from "@/components/loading/Loading";
+import { useUser } from "@/context/UserContext";
 
 const VotePlacePage: React.FC = () => {
   const router = useRouter();
@@ -16,26 +16,9 @@ const VotePlacePage: React.FC = () => {
   const id = params.id as string;
 
   const { selectedTimes } = useTimeVote();
+  const { user } = useUser();
   const [places, setPlaces] = useState<PlaceVote[]>([]);
   const [selectedPlace, setSelectedPlace] = useState<number>();
-  const [userId, setUserId] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchUserId = async () => {
-      try {
-        const user = await getUserIdClient();
-        if (!user) {
-          alert("❌ 로그인이 필요합니다. 로그인 페이지로 이동합니다.");
-          router.push("/login");
-          return;
-        }
-        setUserId(user);
-      } catch (error) {
-        console.error("❌ 유저 정보 가져오기 실패:", error);
-      }
-    };
-    fetchUserId();
-  }, []);
 
   useEffect(() => {
     const fetchPlaces = async () => {
@@ -62,7 +45,7 @@ const VotePlacePage: React.FC = () => {
       alert("❌ 장소를 선택해주세요.");
       return;
     }
-    if (!userId) {
+    if (!user) {
       alert("❌ 로그인이 필요합니다.");
       router.push("/login");
       return;
@@ -72,7 +55,7 @@ const VotePlacePage: React.FC = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId,
+          userId: user.id,
           timeVotes: selectedTimes.map((time) => ({ time })),
           placeVotes: [{ placeId: selectedPlace }],
         }),

--- a/app/user/appointments/[id]/vote-result/page.tsx
+++ b/app/user/appointments/[id]/vote-result/page.tsx
@@ -5,7 +5,6 @@ import TimeResult from "./components/TimeResult";
 import PlaceResult from "./components/PlaceResult";
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { getUserIdClient } from "@/utils/supabase/client";
 import Loading from "@/components/loading/Loading";
 
 interface TimeVoteResult {
@@ -63,22 +62,6 @@ const VoteResultPage = () => {
 
     fetchVoteResult();
   }, [id]);
-  useEffect(() => {
-    const fetchUserId = async () => {
-      try {
-        const user = await getUserIdClient();
-        if (!user) {
-          alert("❌ 로그인이 필요합니다. 로그인 페이지로 이동합니다.");
-          router.push("/login");
-          return;
-        }
-        setUserId(user);
-      } catch (error) {
-        console.error("❌ 유저 정보 가져오기 실패:", error);
-      }
-    };
-    fetchUserId();
-  }, []);
 
   if (!resultData) return <Loading />;
 

--- a/app/user/appointments/[id]/vote-time/page.tsx
+++ b/app/user/appointments/[id]/vote-time/page.tsx
@@ -6,7 +6,6 @@ import Button from "@/components/button/Button";
 import { useParams, useRouter } from "next/navigation";
 import { useTimeVote } from "@/context/TimeVoteContext";
 import Loading from "@/components/loading/Loading";
-import { getUserIdClient } from "@/utils/supabase/client";
 
 const VoteTimePage: React.FC = () => {
   const router = useRouter();
@@ -24,23 +23,6 @@ const VoteTimePage: React.FC = () => {
   const dragValue = useRef<boolean>(false);
   const lastTouchedCell = useRef<{ row: number; col: number } | null>(null); // 터치 드래그 중 같은 셀을 반복적으로 처리하지 않도록 방지
   const touchTimeout = useRef<NodeJS.Timeout | null>(null); // 단순 터치인지 드래그인지 구분
-
-  // 로그인 상태 확인
-  useEffect(() => {
-    const fetchUserId = async () => {
-      try {
-        const user = await getUserIdClient();
-        if (!user) {
-          alert("❌ 로그인이 필요합니다. 로그인 페이지로 이동합니다.");
-          router.push("/login");
-          return;
-        }
-      } catch (error) {
-        console.error("❌ 유저 정보 가져오기 실패:", error);
-      }
-    };
-    fetchUserId();
-  }, []);
 
   useEffect(() => {
     const fetchAppointmentTime = async () => {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 투표페이지에서 getUserIdClient()를 직접 호출하던 방식에서 context에서 호출하여 user/layout.tsx에 감사는 방식으로 변경
- 어드민 페이지의 헤더 추가(어드민 로그아웃을 위함) : 기존에 있던 Header 컴포넌트 이용
