### PR TITLE
[feat] admin 페이지 권한 체크 함수 분리

### DIFF
--- a/app/admin/appointments/page.tsx
+++ b/app/admin/appointments/page.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useState } from "react";
 import styles from "./appointments.module.scss";
 import Link from "next/link";
-import { getUserIdClient } from "@/utils/supabase/client";
-import { useRouter } from "next/navigation";
+import useAdminCheck from "@/hooks/useAdminCheck";
 
 interface Appointment {
   id: number;
@@ -12,33 +11,14 @@ interface Appointment {
   status: "voting" | "confirmed";
   confirm_time: string;
 }
-const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID;
+
 export default function AppointmentsPage() {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [filteredAppointments, setFilteredAppointments] = useState<
     Appointment[]
   >([]);
   const [statusFilter, setStatusFilter] = useState("전체");
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  const [userId, setUserId] = useState<string | null>(null);
-  const router = useRouter();
-
-  useEffect(() => {
-    const checkUser = async () => {
-      const currentUserId = await getUserIdClient();
-      setUserId(currentUserId);
-      if (currentUserId !== ADMIN_USER_ID) {
-        setErrorMessage(
-          "이 페이지는 관리자 전용입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
-        );
-        setTimeout(() => {
-          router.push("/user/appointments");
-        }, 2000);
-      }
-    };
-
-    checkUser();
-  }, [router]);
+  const { errorMessage } = useAdminCheck();
 
   // ✅ 약속 데이터 불러오기
   const fetchAppointments = async () => {

--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useState } from "react";
 import styles from "./images.module.scss";
-import { useRouter } from "next/navigation";
-import { getUserIdClient } from "@/utils/supabase/client";
+import useAdminCheck from "@/hooks/useAdminCheck";
 
 interface Image {
   id: number;
@@ -12,35 +11,16 @@ interface Image {
   creater_id: string;
   created_at: string;
 }
-const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID;
+
 export default function ImagesPage() {
   const [images, setImages] = useState<Image[]>([]);
+  const { errorMessage } = useAdminCheck();
 
   const fetchImages = async () => {
     const res = await fetch("/api/admin/images");
     const data = await res.json();
     setImages(data);
   };
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  const [userId, setUserId] = useState<string | null>(null);
-  const router = useRouter();
-
-  useEffect(() => {
-    const checkUser = async () => {
-      const currentUserId = await getUserIdClient();
-      setUserId(currentUserId);
-      if (currentUserId !== ADMIN_USER_ID) {
-        setErrorMessage(
-          "이 페이지는 관리자 전용입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
-        );
-        setTimeout(() => {
-          router.push("/user/appointments");
-        }, 2000);
-      }
-    };
-
-    checkUser();
-  }, [router]);
 
   useEffect(() => {
     fetchImages();

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -2,16 +2,13 @@
 
 import { useEffect, useState } from "react";
 import styles from "./users.module.scss";
-import { useRouter } from "next/navigation";
-import { getUserIdClient } from "@/utils/supabase/client";
+import useAdminCheck from "@/hooks/useAdminCheck";
 
 interface User {
   id: string;
   email: string;
   nickname: string;
 }
-
-const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID;
 
 export default function UsersPage() {
   const [users, setUsers] = useState<User[]>([]);
@@ -20,26 +17,7 @@ export default function UsersPage() {
     "id"
   );
   const [searchQuery, setSearchQuery] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  const [userId, setUserId] = useState<string | null>(null);
-  const router = useRouter();
-
-  useEffect(() => {
-    const checkUser = async () => {
-      const currentUserId = await getUserIdClient();
-      setUserId(currentUserId);
-      if (currentUserId !== ADMIN_USER_ID) {
-        setErrorMessage(
-          "이 페이지는 관리자 전용입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
-        );
-        setTimeout(() => {
-          router.push("/user/appointments");
-        }, 2000);
-      }
-    };
-
-    checkUser();
-  }, [router]);
+  const { errorMessage } = useAdminCheck();
 
   // ✅ 전체 유저 목록 불러오기
   const fetchUsers = async () => {

--- a/hooks/useAdminCheck.ts
+++ b/hooks/useAdminCheck.ts
@@ -1,0 +1,30 @@
+import { getUserIdClient } from "@/utils/supabase/client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID;
+const useAdminCheck = () => {
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [userId, setUserId] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const checkUser = async () => {
+      const currentUserId = await getUserIdClient();
+      setUserId(currentUserId);
+      if (currentUserId !== ADMIN_USER_ID) {
+        setErrorMessage(
+          "이 페이지는 관리자 전용입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
+        );
+        setTimeout(() => {
+          router.push("/user/appointments");
+        }, 2000);
+      }
+    };
+
+    checkUser();
+  }, [router]);
+
+  return { userId, errorMessage };
+};
+
+export default useAdminCheck;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

```tsx
import { getUserIdClient } from "@/utils/supabase/client";
import { useRouter } from "next/navigation";
import { useEffect, useState } from "react";

const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID;

const useAdminCheck = () => {
  const [errorMessage, setErrorMessage] = useState<string>("");
  const [userId, setUserId] = useState<string | null>(null);
  const router = useRouter();

  useEffect(() => {
    const checkUser = async () => {
      const currentUserId = await getUserIdClient();
      setUserId(currentUserId);
      if (currentUserId !== ADMIN_USER_ID) {
        setErrorMessage(
          "이 페이지는 관리자 전용입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
        );
        setTimeout(() => {
          router.push("/user/appointments");
        }, 2000);
      }
    };

    checkUser();
  }, [router]);

  return { userId, errorMessage };
};

export default useAdminCheck;

```
- 같은 함수를 많이 사용하여 따로 hooks으로 분리하여 재사용하였습니다.
<br />

## :: 기타 질문 및 특이 사항

-
-
