### PR TITLE
[feat] 관리자 페이지 권한 체크 기능 구현

### DIFF
--- a/app/admin/hooks/useAdminCheck.ts
+++ b/app/admin/hooks/useAdminCheck.ts
@@ -1,28 +1,53 @@
 import { getUserIdClient } from "@/utils/supabase/client";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID;
+
 const useAdminCheck = () => {
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [userId, setUserId] = useState<string | null>(null);
+  const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
     const checkUser = async () => {
       const currentUserId = await getUserIdClient();
       setUserId(currentUserId);
-      if (currentUserId !== ADMIN_USER_ID) {
-        setErrorMessage(
-          "이 페이지는 관리자 전용입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
-        );
-        setTimeout(() => {
-          router.push("/user/appointments");
-        }, 2000);
+
+      try {
+        const response = await fetch("/api/admin");
+
+        if (!response.ok) {
+          throw new Error("서버 응답 실패");
+        }
+        const data = await response.json();
+
+        if (data.userInfo.type !== "admin") {
+          setErrorMessage(
+            "이 페이지는 관리자 전용 페이지입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
+          );
+
+          setTimeout(() => {
+            router.push("/user/appointments");
+          }, 2000);
+        }
+
+        if (data?.redirectUrl) {
+          setRedirectUrl(data.redirectUrl);
+        }
+      } catch (error) {
+        console.error("❌ useAdminCheck 오류:", error);
+        setErrorMessage("관리자 권한 확인 중 오류가 발생했습니다.");
       }
     };
 
     checkUser();
   }, [router]);
+
+  useEffect(() => {
+    if (redirectUrl) {
+      router.push(redirectUrl);
+    }
+  }, [redirectUrl, router]);
 
   return { userId, errorMessage };
 };

--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -1,0 +1,37 @@
+import { DfGetUserTypeUsecase } from "@/application/usecases/user/DfGetUserTypeUsecase";
+import { SbUserRepository } from "@/infrastructure/repositories/SbUserRepository";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export const GET = async () => {
+  try {
+    const cookieStore = cookies();
+    const userId = (await cookieStore).get("userId")?.value || null;
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: "userId가 없습니다. 로그인해주세요." },
+        { status: 401 }
+      );
+    }
+    const userRepository = new SbUserRepository();
+    const getUserTypeUsecase = new DfGetUserTypeUsecase(userRepository);
+
+    const userInfo = await getUserTypeUsecase.execute(userId);
+    if (!userInfo) {
+      return NextResponse.json(
+        { error: "유저 정보를 찾을 수 없습니다." },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ userInfo });
+  } catch (error) {
+    console.error("❌ /api/admin GET 요청 오류:", error);
+
+    return NextResponse.json(
+      { error: "서버 내부에 오류가 생겼습니다." },
+      { status: 500 }
+    );
+  }
+};

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -17,9 +17,13 @@ export const POST = async (request: NextRequest) => {
     const authRepository = new SbAuthRepository();
     const loginUsecase = new DfLoginUsecase(authRepository);
 
-    const { token } = await loginUsecase.execute(user_email, password);
+    const { token, user } = await loginUsecase.execute(user_email, password);
 
-    const redirectUrl = `${process.env.SITE_URL}/user/appointments`;
+    console.log("userType", user.type);
+    const redirectUrl =
+      user.type === "admin"
+        ? `${process.env.SITE_URL}/admin/appointments`
+        : `${process.env.SITE_URL}/user/appointments`;
     const response = NextResponse.json({
       redirectUrl,
     });

--- a/application/usecases/auth/dto/LoginResponseDto.ts
+++ b/application/usecases/auth/dto/LoginResponseDto.ts
@@ -5,5 +5,6 @@ export interface LoginResponseDto {
     user_email: string;
     nickname: string;
     emoji: string;
+    type?: string;
   };
 }

--- a/application/usecases/user/DfGetUserTypeUsecase.ts
+++ b/application/usecases/user/DfGetUserTypeUsecase.ts
@@ -1,0 +1,12 @@
+import { SbUserRepository } from "@/infrastructure/repositories/SbUserRepository";
+import { GetUserTypeDto } from "./dto/GetUserTypeDto";
+
+export class DfGetUserTypeUsecase {
+  constructor(private userRepository: SbUserRepository) {}
+
+  async execute(userId: string): Promise<GetUserTypeDto> {
+    const userInfo = await this.userRepository.findById(userId);
+
+    return { type: userInfo.type };
+  }
+}

--- a/application/usecases/user/dto/GetUserTypeDto.ts
+++ b/application/usecases/user/dto/GetUserTypeDto.ts
@@ -1,0 +1,3 @@
+export interface GetUserTypeDto {
+  type: string | undefined;
+}

--- a/infrastructure/repositories/SbAuthRepository.ts
+++ b/infrastructure/repositories/SbAuthRepository.ts
@@ -38,6 +38,7 @@ export class SbAuthRepository implements AuthRepository {
       emoji: userData.emoji,
       created_at: userData.created_at,
       provider: userData.provider,
+      type: userData.type,
       token: token,
     };
   }

--- a/infrastructure/repositories/SbUserRepository.ts
+++ b/infrastructure/repositories/SbUserRepository.ts
@@ -131,6 +131,7 @@ export class SbUserRepository implements UserRepository {
       emoji: user.emoji,
       created_at: new Date(user.created_at),
       provider: user.provider,
+      type: user.type,
     };
   }
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능추가
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 패키지 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

```tsx
import { getUserIdClient } from "@/utils/supabase/client";
import { useRouter } from "next/navigation";
import { useEffect, useState } from "react";

const useAdminCheck = () => {
  const [errorMessage, setErrorMessage] = useState<string>("");
  const [userId, setUserId] = useState<string | null>(null);
  const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
  const router = useRouter();

  useEffect(() => {
    const checkUser = async () => {
      const currentUserId = await getUserIdClient();
      setUserId(currentUserId);

      try {
        const response = await fetch("/api/admin");

        if (!response.ok) {
          throw new Error("서버 응답 실패");
        }
        const data = await response.json();

        if (data.userInfo.type !== "admin") {
          setErrorMessage(
            "이 페이지는 관리자 전용 페이지입니다. 권한이 없는 사용자로는 접근할 수 없습니다."
          );

          setTimeout(() => {
            router.push("/user/appointments");
          }, 2000);
        }

        if (data?.redirectUrl) {
          setRedirectUrl(data.redirectUrl);
        }
      } catch (error) {
        console.error("❌ useAdminCheck 오류:", error);
        setErrorMessage("관리자 권한 확인 중 오류가 발생했습니다.");
      }
    };

    checkUser();
  }, [router]);

  useEffect(() => {
    if (redirectUrl) {
      router.push(redirectUrl);
    }
  }, [redirectUrl, router]);

  return { userId, errorMessage };
};

export default useAdminCheck;

```
- 기존 환경변수로 하드 코딩하여 userId를 비교했던 관리자 페이지를 유저에 type을 추가하여 admin, user로 나누어 admin일 경우 로그인 시 `admin/appointments` 페이지로 리다이렉트합니다. 일반 유저인경우에는 `user/appointments` 로 리다이렉트 합니다.
- 일반 유저가 `admin/appointments` 로 들어올 시 admin인지 확인하여 아니라면 `user/appointments` 로 리다이렉트 합니다.
<br />

## :: 기타 질문 및 특이 사항

-
-
